### PR TITLE
Removed activesupport dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/version_tmp
 tmp
 
 spec/dummy/log/development.log
+.rbenv-*

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    crashlog (1.0.1)
-      activesupport
+    crashlog (1.0.3)
       crashlog-auth-hmac (~> 1.1.6)
       faraday (~> 0.8.4)
       hashr
@@ -58,6 +57,7 @@ GEM
     faraday (0.8.4)
       multipart-post (~> 1.1)
     ffi (1.1.1)
+    ffi (1.1.1-java)
     guard (1.2.3)
       listen (>= 0.4.2)
       thor (>= 0.14.6)
@@ -68,6 +68,7 @@ GEM
     i18n (0.6.0)
     journey (1.0.4)
     json (1.7.4)
+    json (1.7.4-java)
     json_spec (1.0.3)
       multi_json (~> 1.0)
       rspec (~> 2.0)
@@ -85,7 +86,7 @@ GEM
     multi_json (1.3.6)
     multipart-post (1.1.5)
     polyglot (0.3.3)
-    rabl (0.7.2)
+    rabl (0.7.3)
       activesupport (>= 2.3.14)
       multi_json (~> 1.0)
     rack (1.4.1)
@@ -144,6 +145,7 @@ GEM
       macaddr (~> 1.0)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/crashlog.gemspec
+++ b/crashlog.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = CrashLog::VERSION
 
-  gem.add_dependency("activesupport")
   gem.add_dependency("faraday",       '~> 0.8.4')
   gem.add_dependency("multi_json",    '~> 1.3.6')
   gem.add_dependency("crashlog-auth-hmac", '~> 1.1.6')

--- a/lib/crash_log.rb
+++ b/lib/crash_log.rb
@@ -1,6 +1,14 @@
 require 'faraday'
 require 'multi_json'
 
+unless Kernel.respond_to?(:require_relative)
+  module Kernel
+    def require_relative(path)
+      require File.join(File.dirname(caller[0]), path.to_str)
+    end
+  end
+end
+
 require_relative './crash_log/railtie' if defined?(Rails::Railtie)
 require_relative './crash_log/version'
 require_relative './crash_log/logging'

--- a/lib/crash_log.rb
+++ b/lib/crash_log.rb
@@ -1,30 +1,18 @@
-$: << File.expand_path('..', __FILE__)
-
-require 'crash_log/version'
-
-begin
-  require 'active_support'
-  require 'active_support/core_ext'
-rescue LoadError
-  require 'activesupport'
-  require 'activesupport/core_ext'
-end
-
 require 'faraday'
 require 'multi_json'
 
-require 'crash_log/railtie' if defined?(Rails::Railtie)
-require 'crash_log/logging'
+require_relative './crash_log/railtie' if defined?(Rails::Railtie)
+require_relative './crash_log/version'
+require_relative './crash_log/logging'
+require_relative './crash_log/backtrace'
+require_relative './crash_log/configuration'
+require_relative './crash_log/payload'
+require_relative './crash_log/reporter'
+require_relative './crash_log/system_information'
+require_relative './crash_log/rack'
 
 module CrashLog
   extend Logging::ClassMethods
-
-  autoload :Backtrace,          'crash_log/backtrace'
-  autoload :Configuration,      'crash_log/configuration'
-  autoload :Payload,            'crash_log/payload'
-  autoload :Rack,               'crash_log/rack'
-  autoload :Reporter,           'crash_log/reporter'
-  autoload :SystemInformation,  'crash_log/system_information'
 
   LOG_PREFIX = '** [CrashLog]'
 


### PR DESCRIPTION
By doing so, I also cleaned up module loading to not pollute the load path.

I think it is not so good to pull in such a huge dependency like `activesupport` and _fully_ load it only for having the `autoload` feature.

The specs were green before the change.
I removed activesupport and ran all the tests. Everything is still green on `jruby-1.7.0-RC1`.

Please double check if your features are still in place, I just assumed the tests are sufficient.

Cheers, Lukas
