### PR TITLE
Added sidekiq exception trap if the Sidekiq gem is present

### DIFF
--- a/lib/crash_log.rb
+++ b/lib/crash_log.rb
@@ -15,6 +15,8 @@ require_relative 'crash_log/reporter'
 require_relative 'crash_log/system_information'
 require_relative 'crash_log/rack'
 
+require_relative "crash_log/sidekiq" if defined?(Sidekiq)
+
 module CrashLog
   extend Logging::ClassMethods
 

--- a/lib/crash_log/sidekiq.rb
+++ b/lib/crash_log/sidekiq.rb
@@ -1,0 +1,18 @@
+module CrashLog
+  class Sidekiq
+    def call(worker, msg, queue)
+      begin
+        yield
+      rescue => ex
+        CrashLog.notify_or_ignore(ex, :context => {:sidekiq => msg })
+        raise
+      end
+    end
+  end
+end
+
+::Sidekiq.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add ::CrashLog::Sidekiq
+  end
+end


### PR DESCRIPTION
This adds support for CrashLog as an exception notifier to Sidekiq, as described by the Sidekiq gem: https://github.com/mperham/sidekiq/blob/master/lib/sidekiq/exception_handler.rb#L11
