### PR TITLE
README uses CrashLog.configure not CrashLog.configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Generate a Rails Initializer:
 ### Basic:
 
 ```ruby
-CrashLog.configuration do |config|
+CrashLog.configure do |config|
   config.api_key  = "Your API Key"
   config.secret   = "Project Project ID"
 end


### PR DESCRIPTION
CrashLog.configuration does not take a block, which makes the given
example silently fail to configure CrashLog.

(This explains why I've never had an error logged!)
