### PR TITLE
Fix configuration.rb link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ end
 
 ### Advanced
 
-See [configuration.rb](/crashlog/crashlog/blob/master/lib/crash_log/configuration.rb)
+See [configuration.rb](/lib/crash_log/configuration.rb)
 for available options.
 
 ## Contributing


### PR DESCRIPTION
GitHub has changed how relative links work.

https://github.com/blog/1395-relative-links-in-markup-files
