### PR TITLE
Before notify hook

### DIFF
--- a/lib/crash_log.rb
+++ b/lib/crash_log.rb
@@ -48,6 +48,8 @@ module CrashLog
     #
     # Returns true if successful, otherwise false
     def notify(exception, data = {})
+      exception = configuration.before_notify_hook.call(exception, data) if configuration.before_notify_hook.respond_to?(:call)
+
       send_notification(exception, data).tap do |notification|
         if notification
           info "Event sent to CrashLog.io"

--- a/lib/crash_log.rb
+++ b/lib/crash_log.rb
@@ -48,7 +48,9 @@ module CrashLog
     #
     # Returns true if successful, otherwise false
     def notify(exception, data = {})
-      exception = configuration.before_notify_hook.call(exception, data) if configuration.before_notify_hook.respond_to?(:call)
+      if ! configuration.before_notify_hook.nil? && configuration.before_notify_hook.respond_to?(:call)
+        exception = configuration.before_notify_hook.call(exception, data)
+      end
 
       send_notification(exception, data).tap do |notification|
         if notification

--- a/lib/crash_log/configuration.rb
+++ b/lib/crash_log/configuration.rb
@@ -168,7 +168,7 @@ module CrashLog
       # Before notify hook
       # Must be an object which responds to call with the exception and payload hash as parameters.
       # Will be called within Crashlog.notify before Crashlog.send_notification.
-      :before_notify_hook => nil
+      :before_notify_hook => ->(exception, data) { exception }
 
     def root
       fetch(:project_root)

--- a/lib/crash_log/configuration.rb
+++ b/lib/crash_log/configuration.rb
@@ -163,7 +163,12 @@ module CrashLog
       # Development mode
       # When enabled we don't swallow internal exceptions.
       # Useful for debugging connection issues.
-      :development_mode => false
+      :development_mode => false,
+
+      # Before notify hook
+      # Must be an object which responds to call with the exception and payload hash as parameters.
+      # Will be called within Crashlog.notify before Crashlog.send_notification.
+      :before_notify_hook => nil
 
     def root
       fetch(:project_root)

--- a/spec/crash_log_spec.rb
+++ b/spec/crash_log_spec.rb
@@ -60,7 +60,7 @@ describe CrashLog do
         exception # should always return an exception like object
       }
       set_before_notify_hook(hook)
-      CrashLog.configuration.before_notify_hook.should_receive(:call).and_return(raised_error)
+      hook.should_receive(:call).and_return(raised_error)
       CrashLog.notify(raised_error)
     end
 


### PR DESCRIPTION
Hi guys,

We have a requirement to mess with the exception and/or data of a notification before it gets sent to crashlog.io. Our Rails application runs on various servers, for example staging, uat and app. These all use the same Rails 'production' environment though, so its not easy to tell which server actually generated the error.

What do you think of a before_notify_hook which gets called within the Crashlog.notify method? An example rails/crashlog initializer would look like:-

``` ruby
CrashLog.configure do |config|
  config.api_key = 'my key'
  config.secret = 'my secret'

  config.before_notify_hook = ->(exception, data) {
    data[:system][:location] = 'custom setting'
    WrappedException.new('message wrapper, original message: ', exception)
  }
end
```

Another option is to monkey-patch/alias the Crashlog.notify method in order to keep the hook independent of the Crashlog gem, not as elegant though.

Thoughts?
